### PR TITLE
Make ics-openvpn work with Android Rebuilds

### DIFF
--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         targetSdkVersion(30)  //'Q'.toInt()
         versionCode = 176
         versionName = "0.7.22"
-
+	    ndkVersion = "21.4.0"
         externalNativeBuild {
             cmake {
                 //arguments = listOf("-DANDROID_TOOLCHAIN=clang",

--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -25,6 +25,7 @@ android {
 	    ndkVersion = "21.4.0"
         externalNativeBuild {
             cmake {
+                version = "3.10.3+"
                 //arguments = listOf("-DANDROID_TOOLCHAIN=clang",
                 //        "-DANDROID_STL=c++_static")
             }
@@ -36,6 +37,7 @@ android {
 
     externalNativeBuild {
         cmake {
+            version = "3.10.3+"
             path =File("${projectDir}/src/main/cpp/CMakeLists.txt")
         }
     }


### PR DESCRIPTION
These changes make sure that https://github.com/eduvpn/android/pull/327 will work.
They include:
- Setting a minimum NDK version:
This will allow use of a different NDK version than is served by sdk-manager by default i.e. a newer version or one that is self-compiled.
- Setting a minimum cmake version:
This will make gradle check if the version of cmake present in your PATH variable is suitable for use to build ics-openvpn. To use functionality you _need_ to specify a version that isn't 3.10.2 (which is what sdk-manager ships by default) or lower. Otherwise the build will error out on a "license not accepted" error which just means that sdk-manager is trying to download 3.10.2 from Google.

There is more information in https://github.com/eduvpn/android/pull/327 and in the commit messages.